### PR TITLE
Lean4関連のパッケージの参照先を変更

### DIFF
--- a/configuration/common.nix
+++ b/configuration/common.nix
@@ -23,7 +23,6 @@
   # nix registry config
   nix.registry = {
     nixpkgs.flake = attrs.nixpkgs;
-    lean4.flake = attrs.lean4;
   };
 
   nixpkgs.config = {
@@ -118,7 +117,6 @@
       sys = config.nixpkgs.localSystem.system;
     in {
       pkgs-unstable = attrs.nixpkgs-unstable.legacyPackages."${sys}";
-      lean4-packages = attrs.lean4.packages.${sys};
     };
   };
 }

--- a/configuration/linux.nix
+++ b/configuration/linux.nix
@@ -15,10 +15,6 @@
     keep-outputs = true
     keep-derivations = true
     max-jobs = auto  # Allow building multiple derivations in parallel
-
-    # Allow fetching build results from the Lean Cachix cache
-    trusted-substituters = https://lean4.cachix.org/
-    trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= lean4.cachix.org-1:mawtxSxcaiWE24xCXXgh3qnvlTkyU7evRRnGeAhD4Wk=
   '';
 
   boot.isContainer = false;

--- a/configuration/wsl2.nix
+++ b/configuration/wsl2.nix
@@ -23,10 +23,6 @@
     keep-outputs = false
     keep-derivations = false
     max-jobs = auto  # Allow building multiple derivations in parallel
-
-    # Allow fetching build results from the Lean Cachix cache
-    trusted-substituters = https://lean4.cachix.org/
-    trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= lean4.cachix.org-1:mawtxSxcaiWE24xCXXgh3qnvlTkyU7evRRnGeAhD4Wk=
   '';
 
   # Configure network proxy if necessary

--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1701766395,
-        "narHash": "sha256-lC8XOwVPBrEPZB4ssqaiVNm4rWkrYgxHRyaLHnBUxNw=",
+        "lastModified": 1702399955,
+        "narHash": "sha256-FnB5O1RVFzj3h7Ayf7UxFnOL1gsJuG6gn1LCTd9dKFs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5bc76d2e18a8592d49e1539e7eb79a95a3f2ce1c",
+        "rev": "47798c4ab07d5f055bb2625010cf6d8e3f384923",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698882062,
-        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700814205,
-        "narHash": "sha256-lWqDPKHRbQfi+zNIivf031BUeyciVOtwCwTjyrhDB5g=",
+        "lastModified": 1702676849,
+        "narHash": "sha256-XqcREaTS38/QOsN8fk8PP325/UXHyF9enbP5ZPw5aiA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aeb2232d7a32530d3448318790534d196bf9427a",
+        "rev": "aa99c2f4e9847cbb7e46fac0844ea1eb164b3b3a",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1701773410,
-        "narHash": "sha256-Juqn2t5UniRi7D2oGKxDtnofFvoPA3z4qxJzZTiYIRI=",
+        "lastModified": 1702700445,
+        "narHash": "sha256-P5ax8JLhlIoOAXe/qthbvppDhZw+SUn4ikqLLZ52afE=",
         "owner": "leanprover",
         "repo": "lean4",
-        "rev": "d4f10bc07e575de14edd08ccbcda55e6dd3fa823",
+        "rev": "4497aba1a985619023adf0e1c655e769b12735e7",
         "type": "github"
       },
       "original": {
@@ -278,11 +278,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700033161,
-        "narHash": "sha256-CHD4T1dS+Z+2MX4Ox1EhNgsM6J+RVFU/jzvIfO8DKJs=",
+        "lastModified": 1702639936,
+        "narHash": "sha256-Fz5KsFVXB1xu2J4Hmr514vK3eir16/z1Mrv60HjzFtA=",
         "owner": "thiagokokada",
         "repo": "nix-alien",
-        "rev": "d37ba197c51addb2979a042769c5fd1e2b76412a",
+        "rev": "7d36757ddef3c2fb1805126e0da9abc9d88060f8",
         "type": "github"
       },
       "original": {
@@ -300,11 +300,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1701608160,
-        "narHash": "sha256-6QqrMzjIkUD5mVTWq0L8kM+wlhk6B95rmC91pt2o0dA=",
+        "lastModified": 1702677673,
+        "narHash": "sha256-BPcLfyyXinIyya48fTl3sg3bXhgN6hXx5xfQVLm4hO0=",
         "owner": "nix-community",
         "repo": "nix-direnv",
-        "rev": "6bd877b73cfcf5c82232d90f590dba32535580b6",
+        "rev": "499255d0189982b93d1e9aa9297823132d95a86c",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1694857738,
-        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
+        "lastModified": 1701697642,
+        "narHash": "sha256-L217WytWZHSY8GW9Gx1A64OnNctbuDbfslaTEofXXRw=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
+        "rev": "c843418ecfd0344ecb85844b082ff5675e02c443",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1699760693,
-        "narHash": "sha256-u/gkNUHQR/q23voqE5J4xmEWQIAqR+g3lUnCtzn0k7Y=",
+        "lastModified": 1702291765,
+        "narHash": "sha256-kfxavgLKPIZdYVPUPcoDZyr5lleymrqbr5G9PVfQ2NY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "8aff4ca3dee60d1422489fe8d52c2f837b3ad113",
+        "rev": "45d82e0a8b9dd6c5dd9da835ac0c072239af7785",
         "type": "github"
       },
       "original": {
@@ -375,11 +375,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701722881,
-        "narHash": "sha256-Wim+dqT6W6nTdifu/jmToIzD7eCQaCEhDqDp5kexyfM=",
+        "lastModified": 1702728584,
+        "narHash": "sha256-KOfJihF3QRVjakvLg+JeK6B0raexiiI0ib2TY3Ve+eQ=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "5ee4fa3515de7b5609e6d161b800d91328a7a143",
+        "rev": "092b4239169477b6e785ae22db56318439351315",
         "type": "github"
       },
       "original": {
@@ -390,11 +390,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701436327,
-        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
+        "lastModified": 1702151865,
+        "narHash": "sha256-9VAt19t6yQa7pHZLDbil/QctAgVsA66DLnzdRGqDisg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
+        "rev": "666fc80e7b2afb570462423cb0e1cf1a3a34fedd",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1701540982,
-        "narHash": "sha256-5ajSy6ODgGmAbmymRdHnjfVnuVrACjI8wXoGVvrtvww=",
+        "lastModified": 1702221085,
+        "narHash": "sha256-Br3GCSkkvkmw46cT6wCz6ro2H1WgDMWbKE0qctbdtL0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6386d8aafc28b3a7ed03880a57bdc6eb4465491d",
+        "rev": "c2786e7084cbad90b4f9472d5b5e35ecb57958af",
         "type": "github"
       },
       "original": {
@@ -438,11 +438,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1701436327,
-        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
+        "lastModified": 1702312524,
+        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
         "type": "github"
       },
       "original": {
@@ -486,11 +486,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1699099776,
-        "narHash": "sha256-X09iKJ27mGsGambGfkKzqvw5esP1L/Rf8H3u3fCqIiU=",
+        "lastModified": 1701718080,
+        "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85f1ba3e51676fa8cc604a3d863d729026a6b8eb",
+        "rev": "2c7f3c0fb7c08a0814627611d9d7d45ab6d75335",
         "type": "github"
       },
       "original": {
@@ -502,11 +502,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1701539137,
-        "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
+        "lastModified": 1702346276,
+        "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "933d7dc155096e7575d207be6fb7792bc9f34f6d",
+        "rev": "cf28ee258fd5f9a52de6b9865cdb93a1f96d09b7",
         "type": "github"
       },
       "original": {
@@ -584,11 +584,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699786194,
-        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "lastModified": 1702461037,
+        "narHash": "sha256-ssyGxfGHRuuLHuMex+vV6RMOt7nAo07nwufg9L5GkLg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "rev": "d06b70e5163a903f19009c3f97770014787a080f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -108,21 +108,6 @@
       }
     },
     "flake-utils_2": {
-      "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
       "inputs": {
         "systems": "systems_2"
       },
@@ -140,7 +125,7 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
       "inputs": {
         "systems": "systems_3"
       },
@@ -194,83 +179,10 @@
         "type": "github"
       }
     },
-    "lean4": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "lean4-mode": "lean4-mode",
-        "nix": "nix",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1702700445,
-        "narHash": "sha256-P5ax8JLhlIoOAXe/qthbvppDhZw+SUn4ikqLLZ52afE=",
-        "owner": "leanprover",
-        "repo": "lean4",
-        "rev": "4497aba1a985619023adf0e1c655e769b12735e7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "leanprover",
-        "repo": "lean4",
-        "type": "github"
-      }
-    },
-    "lean4-mode": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1689286482,
-        "narHash": "sha256-tD5Ysa24fMIS6ipFc50OjabZEUge4riSb7p4BR05ReQ=",
-        "owner": "leanprover",
-        "repo": "lean4-mode",
-        "rev": "d1c936409ade7d93e67107243cbc0aa55cda7fd5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "leanprover",
-        "repo": "lean4-mode",
-        "type": "github"
-      }
-    },
-    "lowdown-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
-    "nix": {
-      "inputs": {
-        "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1657097207,
-        "narHash": "sha256-SmeGmjWM3fEed3kQjqIAO8VpGmkC2sL1aPE7kKpK650=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "f6316b49a0c37172bca87ede6ea8144d7d89832f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "nix-alien": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nix-filter": "nix-filter",
         "nix-index-database": "nix-index-database",
         "nixpkgs": [
@@ -330,7 +242,7 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1702291765,
@@ -369,7 +281,7 @@
     "nixos-wsl": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -401,22 +313,6 @@
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       }
     },
@@ -454,38 +350,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1653988320,
-        "narHash": "sha256-ZaqFFsSDipZ6KVqriwM34T739+KLYJvNmCWzErjAg7c=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "2fa57ed190fd6c7c746319444f34b5917666e5c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1686089707,
-        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1701718080,
         "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
         "owner": "nixos",
@@ -500,7 +364,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1702346276,
         "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
@@ -522,12 +386,11 @@
         "emacs-overlay": "emacs-overlay",
         "hnakano863": "hnakano863",
         "home-manager": "home-manager",
-        "lean4": "lean4",
         "nix-alien": "nix-alien",
         "nix-direnv": "nix-direnv",
         "nix-ld": "nix-ld",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,6 @@
     eijiro.url = "path:/home/hnakano/ghq/github.com/hnakano/eijiro.nix";
     eijiro.inputs.nixpkgs.follows = "nixpkgs";
 
-    lean4.url = "github:leanprover/lean4";
-    lean4.inputs.lean4-mode = {
-      url = "github:leanprover/lean4-mode";
-      flake = false;
-    };
-
   };
 
   outputs =
@@ -45,7 +39,6 @@
     , nix-alien
     , hnakano863
     , eijiro
-    , lean4
     } @ attrs:
 
     {

--- a/home/hnakano/emacs/default.nix
+++ b/home/hnakano/emacs/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, pkgs-unstable, lean4-packages, ... }:
+{ config, pkgs, lib, pkgs-unstable, ... }:
 with pkgs;
 with lib;
 let
@@ -16,7 +16,7 @@ in
   ];
 
   programs.emacs.enable = true;
-  programs.emacs.overrides = import ./overrides { inherit pkgs lean4-packages; };
+  programs.emacs.overrides = import ./overrides { inherit pkgs; };
   programs.emacs.package = emacs29;
 
   programs.emacs.compileInit = {

--- a/home/hnakano/emacs/extraPackages.nix
+++ b/home/hnakano/emacs/extraPackages.nix
@@ -26,6 +26,8 @@
       eglot-jl
       elfeed
       elm-mode
+      embark
+      embark-consult
       envrc
       ess
       evil

--- a/home/hnakano/emacs/extraPackages.nix
+++ b/home/hnakano/emacs/extraPackages.nix
@@ -50,7 +50,7 @@
       jupyter
       leaf
       leaf-convert
-      lean4-mode
+      # lean4-mode
       macrostep
       magit
       marginalia

--- a/home/hnakano/emacs/extraPackages.nix
+++ b/home/hnakano/emacs/extraPackages.nix
@@ -50,7 +50,7 @@
       jupyter
       leaf
       leaf-convert
-      # lean4-mode
+      lean4-mode
       macrostep
       magit
       marginalia

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -113,7 +113,9 @@
     (consult-customize
      consult-recent-file consult--source-recent-file consult--source-project-recent-file
      :preview-key '(:debounce 0.5 any)))
-  (leaf marginalia :global-minor-mode t))
+  (leaf marginalia :global-minor-mode t)
+  (leaf embark-consult
+    :hook (embark-collect-mode-hook . consult-preview-at-point-mode)))
 
 (leaf projectile
   :global-minor-mode t

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -114,6 +114,9 @@
      consult-recent-file consult--source-recent-file consult--source-project-recent-file
      :preview-key '(:debounce 0.5 any)))
   (leaf marginalia :global-minor-mode t)
+  (leaf embark
+    :config
+    (setq prefix-help-command #'embark-prefix-help-command))
   (leaf embark-consult
     :hook (embark-collect-mode-hook . consult-preview-at-point-mode)))
 

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -117,7 +117,7 @@
   (leaf embark
     :bind
     ("C-." . embark-act)
-    ("M-." . embark-dwim)
+    ("C-;" . embark-dwim)
     ("C-h b" . embark-bindings)
     :config
     (setq prefix-help-command #'embark-prefix-help-command))

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -382,7 +382,7 @@
   (leaf markdown-mode
     :mode ("\\.md\\'" . gfm-mode)
     :custom (markdown-command . "pandoc --from gfm"))
-  (leaf lean4-mode :mode "\\.lean\\'")
+  ;(leaf lean4-mode :mode "\\.lean\\'")
   (leaf mermaid-mode :mode "\\.mermaid\\'")
   (leaf rust-mode :mode "\\.rs\\'")
   (leaf js-mode :mode "\\.gs\\'"))

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -382,7 +382,7 @@
   (leaf markdown-mode
     :mode ("\\.md\\'" . gfm-mode)
     :custom (markdown-command . "pandoc --from gfm"))
-  ;(leaf lean4-mode :mode "\\.lean\\'")
+  (leaf lean4-mode :mode "\\.lean\\'")
   (leaf mermaid-mode :mode "\\.mermaid\\'")
   (leaf rust-mode :mode "\\.rs\\'")
   (leaf js-mode :mode "\\.gs\\'"))

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -115,6 +115,10 @@
      :preview-key '(:debounce 0.5 any)))
   (leaf marginalia :global-minor-mode t)
   (leaf embark
+    :bind
+    ("C-." . embark-act)
+    ("M-." . embark-dwim)
+    ("C-h b" . embark-bindings)
     :config
     (setq prefix-help-command #'embark-prefix-help-command))
   (leaf embark-consult
@@ -683,7 +687,8 @@ _j_: next _k_: previous _s_: stage _r_: revert _d_: popup diff"
       "k" 'helpful-key
       "m" 'describe-mode
       "w" 'dictionary-match-words
-      "i" 'info))
+      "i" 'info
+      "b" 'embark-bindings))
   (leaf my/bind-quit
     :config
     (my/bind

--- a/home/hnakano/emacs/overrides/default.nix
+++ b/home/hnakano/emacs/overrides/default.nix
@@ -18,9 +18,6 @@ self: super: {
     '';
   });
 
-#  lean4-mode = self.melpaBuild {
-#    inherit (lean4-packages.lean4-mode) pname version commit src recipe;
-#    packageRequires = with self; [ dash f flycheck magit-section lsp-mode s ];
-#  };
+  lean4-mode = self.callPackage ./lean4-mode.nix { inherit (pkgs) fetchFromGitHub writeText; };
 
 }

--- a/home/hnakano/emacs/overrides/default.nix
+++ b/home/hnakano/emacs/overrides/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lean4-packages, ... }:
+{ pkgs, ... }:
 self: super: {
   evil = self.melpaPackages.evil;
   ddskk = pkgs.callPackage ./ddskk {};
@@ -18,9 +18,9 @@ self: super: {
     '';
   });
 
-  lean4-mode = self.melpaBuild {
-    inherit (lean4-packages.lean4-mode) pname version commit src recipe;
-    packageRequires = with self; [ dash f flycheck magit-section lsp-mode s ];
-  };
+#  lean4-mode = self.melpaBuild {
+#    inherit (lean4-packages.lean4-mode) pname version commit src recipe;
+#    packageRequires = with self; [ dash f flycheck magit-section lsp-mode s ];
+#  };
 
 }

--- a/home/hnakano/emacs/overrides/lean4-mode.nix
+++ b/home/hnakano/emacs/overrides/lean4-mode.nix
@@ -1,0 +1,30 @@
+{ melpaBuild
+, fetchFromGitHub
+, writeText
+, dash
+, f
+, flycheck
+, magit-section
+, lsp-mode
+, s
+}:
+
+# ref: https://github.com/leanprover/lean4/blob/8475ec7e362f3f80809973fcdda410388f72b42b/nix/packages.nix#L48-L60
+melpaBuild {
+  pname = "lean4-mode";
+  version = "1";
+  commit = "1";
+  src = fetchFromGitHub {
+    owner = "leanprover";
+    repo = "lean4-mode";
+    rev = "d1c936409ade7d93e67107243cbc0aa55cda7fd5";
+    hash = "sha256-tD5Ysa24fMIS6ipFc50OjabZEUge4riSb7p4BR05ReQ=";
+  };
+  packageRequires = [ dash f flycheck magit-section lsp-mode s ];
+  recipe = writeText "recipe" ''
+    (lean4-mode
+     :repo "leanprover/lean4-mode"
+     :fetcher github
+     :files ("*el" "data"))
+  '';
+}

--- a/home/hnakano/language/default.nix
+++ b/home/hnakano/language/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, lean4-packages, ... }:
+{ pkgs, ... }:
 {
   imports = [
     ./julia
@@ -18,7 +18,6 @@
     dotnet-sdk_6
     nodePackages.vscode-json-languageserver
     nodePackages.mermaid-cli
-    lean4-packages.lean-all
     # rust
     rustc
     cargo

--- a/home/hnakano/language/default.nix
+++ b/home/hnakano/language/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, pkgs-unstable, ... }:
 {
   imports = [
     ./julia
@@ -18,6 +18,7 @@
     dotnet-sdk_6
     nodePackages.vscode-json-languageserver
     nodePackages.mermaid-cli
+    pkgs-unstable.lean4
     # rust
     rustc
     cargo


### PR DESCRIPTION
これまで、Lean4関連のパッケージは [leanprover/lean4のリポジトリ](https://github.com/leanprover/lean4)からflakeを介してインストールしていたが、インストールのたびにlean4のビルドが走っていて辛かった。

今回、lean4本体を[NixOS/nixpkgs/nixos-unstable](https://github.com/NixOS/nixpkgs/tree/nixos-unstable)から引っ張ってくるように変えて、ローカルでのlean4のビルドを回避するようにした。

また、これまでlean4のflakeから引っ張っていたlean4-modeも[leanprover/lean4-mode](https://github.com/leanprover/lean4-mode)からソースをダウンロードしてmelpaBuildする構成に変え、lean4のflakeへの依存そのものが不要となったので、flakeを削除している。