### PR TITLE
fix xdg auto start

### DIFF
--- a/configuration/linux.nix
+++ b/configuration/linux.nix
@@ -40,11 +40,13 @@
 
   # Select internationalisation properties.
   i18n.defaultLocale = "ja_JP.UTF-8";
-  i18n.inputMethod.enabled = "fcitx5";
-  i18n.inputMethod.fcitx5.addons = with pkgs; [
-    fcitx5-gtk
-    fcitx5-skk
-  ];
+  i18n.inputMethod = {
+    enabled = "fcitx5";
+    fcitx5.addons = with pkgs; [
+      fcitx5-gtk
+      fcitx5-mozc
+    ];
+  };
   console = {
     font = "Lat2-Terminus16";
     useXkbConfig = true;
@@ -115,7 +117,10 @@
       extraPackages = ps: with ps; [ xmonad-contrib ];
     };
 
-    desktopManager.gnome.enable = false;
+    desktopManager = {
+      gnome.enable = false;
+      runXdgAutostartIfNone = true;
+    };
 
     displayManager = {
       defaultSession = "none+xmonad";


### PR DESCRIPTION
関連issue: https://github.com/hnakano863/configuration.nix/issues/7

`services.xserver.desktopManager.runXdgAutostartIfNone = true;`を設定に追加。
参考: https://oreshinya.hatenablog.com/entry/2023/12/02/221514

ついでに、fcitx5-skkではなく、fcitx5-mozcの方が使いやすいので、そちらに変更。