### PR TITLE
yasnippetを導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
 bravo.qcow2
+.projectile-cache.eld

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -236,7 +236,7 @@
     :config
     (doom-modeline-def-modeline 'my/main
       '(bar window-number modals buffer-info " " buffer-position)
-      '(misc-info process checker repl lsp vcs indent-info buffer-encoding "   "))
+      '(misc-info process repl lsp vcs indent-info buffer-encoding "   "))
     (doom-modeline-set-modeline 'my/main t)
     (set-face-attribute 'mode-line nil :family "HackGen" :height 120)
     (set-face-attribute 'mode-line-inactive nil :family "HackGen" :height 120)))

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -301,7 +301,6 @@
   (leaf rainbow-delimiters
     :hook ((emacs-lisp-mode-hook org-mode-hook) . rainbow-delimiters-mode))
   (leaf prism
-    :mode (("\\.sqlx\\'" "\\.lkml\\'") . prism-mode)
     :defer-config
     (prism-set-colors :lightens '(0 5 10) :desaturations '(-2.5 0 2.5)
       :colors (-map #'doom-color '(red orange yellow green blue violet)))))
@@ -416,7 +415,11 @@
   (leaf lean4-mode :mode "\\.lean\\'")
   (leaf mermaid-mode :mode "\\.mermaid\\'")
   (leaf rust-mode :mode "\\.rs\\'")
-  (leaf js-mode :mode "\\.gs\\'"))
+  (leaf js-mode :mode "\\.gs\\'")
+  (leaf dataform
+    :mode ("\\.sqlx\\'" . prism-mode))
+  (leaf lookml
+    :mode ("\\.lkml\\'" . prism-mode)))
 
 (leaf org
   :doc "org-mode and its extentions"

--- a/home/hnakano/emacs/my-init.el
+++ b/home/hnakano/emacs/my-init.el
@@ -303,7 +303,10 @@
   (leaf prism
     :defer-config
     (prism-set-colors :lightens '(0 5 10) :desaturations '(-2.5 0 2.5)
-      :colors (-map #'doom-color '(red orange yellow green blue violet)))))
+      :colors (-map #'doom-color '(red orange yellow green blue violet))))
+  (leaf yasnippet
+    :defer-config
+    (yas-reload-all)))
 
 (leaf language
   :doc "programming language setup"
@@ -416,10 +419,30 @@
   (leaf mermaid-mode :mode "\\.mermaid\\'")
   (leaf rust-mode :mode "\\.rs\\'")
   (leaf js-mode :mode "\\.gs\\'")
-  (leaf dataform
-    :mode ("\\.sqlx\\'" . prism-mode))
-  (leaf lookml
-    :mode ("\\.lkml\\'" . prism-mode)))
+  (leaf dataform-mode
+    :custom
+    (yas-indent-line . 'fixed)
+    :preface
+    (define-derived-mode dataform-mode prog-mode "Dataform"
+      "Major mode for dataform"
+      (setq-local tab-width 2)
+      (setq indent-tabs-mode nil))
+    :mode "\\.sqlx\\'"
+    :hook
+    (dataform-mode-hook . prism-mode)
+    (dataform-mode-hook . yas-minor-mode))
+  (leaf lookml-mode
+    :custom
+    (yas-indent-line . 'fixed)
+    :preface
+    (define-derived-mode lookml-mode prog-mode "LookML"
+      "Major mode for LookML"
+      (setq-local tab-width 2)
+      (setq indent-tabs-mode nil))
+    :mode "\\.lkml\\'"
+    :hook
+    (lookml-mode-hook . prism-mode)
+    (lookml-mode-hook . yas-minor-mode)))
 
 (leaf org
   :doc "org-mode and its extentions"

--- a/home/hnakano/emacs/yasnippet/dataform-mode/config
+++ b/home/hnakano/emacs/yasnippet/dataform-mode/config
@@ -1,0 +1,18 @@
+# -*- mode: snippet -*-
+# name: config { ... }
+# key: config
+# --
+config {
+  type: "table",
+  name: "${1:name}",
+  schema: "${2:schema}",
+  description: "${3:description}",
+  columns: {
+    name: "",
+  },
+  assertions: {
+    uniqueKey: [""],
+    nonNull: [""]
+  },
+  tags: ["daily"]
+}

--- a/home/hnakano/emacs/yasnippet/dataform-mode/min_dt
+++ b/home/hnakano/emacs/yasnippet/dataform-mode/min_dt
@@ -1,0 +1,11 @@
+# -*- mode: snippet -*-
+# name: pre_operations { declare min_dt default ( ... ) }
+# key: min_dt
+# --
+pre_operations {
+  declare min_dt default (
+    ${when(incremental(),
+      "",
+      "")}
+  )
+}

--- a/home/hnakano/emacs/yasnippet/default.nix
+++ b/home/hnakano/emacs/yasnippet/default.nix
@@ -1,0 +1,9 @@
+{ config, ... }:
+{
+
+  home.file.".emacs.d/snippets/dataform-mode" = {
+    source = ./dataform-mode;
+    recursive = true;
+  };
+
+}

--- a/home/hnakano/wsl2.nix
+++ b/home/hnakano/wsl2.nix
@@ -9,6 +9,8 @@ let
 
 in {
 
+  imports = [ ./emacs/yasnippet ];
+
   home.packages = with pkgs; [
     awscli2
     aws-vault


### PR DESCRIPTION
dataform, lookml用にyasnippetを導入した。

これまで、dataformやlookmlには専用のメジャーモードを設けていなかったが、yasnippetの導入にあたって最低限度のメジャーモードを作成した。

## 関連issue
#26